### PR TITLE
Task9 core delete comments

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -65,3 +65,14 @@ export const fetchUsers = () => {
       throw error;
     });
 };
+
+export const deleteCommentById = (commentID) => {
+  return api
+    .delete(`/comments/${commentID}`)
+    .then((response) => {
+      return response.data;
+    })
+    .catch((error) => {
+      throw error;
+    });
+};

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -41,6 +41,8 @@ export default function Login() {
         .finally(() => {
           setOnLoad(false);
         });
+    } else {
+      setOnLoad(false);
     }
   }, [isLogin]);
 


### PR DESCRIPTION
task 9:
- add functional delete comment button (only able to delete their own comments)
- delete button would only show on the comments that has same username as logged in user
- create a fake deleted effect (removes it from commentsShowing)
- alert would be shown when comment has been deleted successfully on the server side
- alert would be shown when comment has failed to be deleted
- roll back of deleted comment would happen when failed to delete (revert the commentsShowing back to allComments)
- new comments have their delete button and like button disabled until the page rerenders or page refresh to prevent interacting with fake comments

additional:
- after sending comment the send button would be disabled until the server has processed the result
- roll back of comments would happen when comment has failed to send (same logic as above). 


